### PR TITLE
Process prompts from file and send to fooocus

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,12 @@
 import argparse
 import logging
 import sys
-from typing import Optional
+from typing import Optional, List
 
 from src.logger import setup_logging
 from src.fooocus_client import FooocusClient
 from src.models import GenerationParams
+from src.prompts_parser import parse_prompts_file
 
 
 def main() -> None:
@@ -13,7 +14,12 @@ def main() -> None:
     logger = setup_logging()
 
     parser = argparse.ArgumentParser(description="Automate Fooocus via Gradio API")
-    parser.add_argument("--prompt", required=True, help="Main text prompt")
+    # Prompt inputs
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument("--prompt", help="Main text prompt")
+    group.add_argument("--prompts_file", help="Path to text file with prompts; separate prompts with lines containing only '---'")
+    parser.add_argument("--delimiter", default="---", help="Delimiter line used to split prompts in file")
+    # Generation options
     parser.add_argument("--negative_prompt", default="", help="Negative prompt")
     parser.add_argument("--num_images", type=int, default=1, help="Number of images to generate")
     parser.add_argument("--seed", default="0", help="Seed value as string (0 for random)")
@@ -30,20 +36,53 @@ def main() -> None:
             logger.info("Inspection summary: %s", info.get("summary"))
             print(info.get("summary"))
             return
-        if args.simple:
-            result = client.generate_simple(prompt=args.prompt, num_images=args.num_images)
-        else:
-            params = GenerationParams(
-                prompt=args.prompt,
-                negative_prompt=args.negative_prompt,
-                num_images=args.num_images,
-                seed=args.seed,
-            )
-            result = client.configure_and_generate(params)
+        # Validate prompt inputs when not inspecting
+        if not args.prompt and not args.prompts_file:
+            parser.error("one of --prompt or --prompts_file is required unless using --inspect")
 
-        logger.info("Generation completed")
-        # Print minimal result to stdout for scripting
-        print(result)
+        # Single prompt path
+        if args.prompt:
+            if args.simple:
+                result = client.generate_simple(prompt=args.prompt, num_images=args.num_images)
+            else:
+                params = GenerationParams(
+                    prompt=args.prompt,
+                    negative_prompt=args.negative_prompt,
+                    num_images=args.num_images,
+                    seed=args.seed,
+                )
+                result = client.configure_and_generate(params)
+            logger.info("Generation completed")
+            print(result)
+            return
+
+        # Batch file path
+        prompts: List[str] = parse_prompts_file(args.prompts_file, delimiter=args.delimiter)
+        if not prompts:
+            logger.error("No prompts found in file '%s'", args.prompts_file)
+            sys.exit(2)
+        total = len(prompts)
+        failures = 0
+        for idx, prompt_text in enumerate(prompts, start=1):
+            try:
+                logger.info("[%d/%d] Generating for prompt (%d chars)", idx, total, len(prompt_text))
+                if args.simple:
+                    client.generate_simple(prompt=prompt_text, num_images=args.num_images)
+                else:
+                    params = GenerationParams(
+                        prompt=prompt_text,
+                        negative_prompt=args.negative_prompt,
+                        num_images=args.num_images,
+                        seed=args.seed,
+                    )
+                    client.configure_and_generate(params)
+                logger.info("[%d/%d] Completed", idx, total)
+            except Exception as exc:  # noqa: BLE001
+                failures += 1
+                logging.exception("[%d/%d] Generation failed: %s", idx, total, exc)
+                continue
+        logger.info("Batch completed: total=%d, failures=%d", total, failures)
+        print({"total": total, "failures": failures})
     except Exception as exc:  # noqa: BLE001
         logging.exception("Generation failed: %s", exc)
         sys.exit(1)

--- a/src/prompts_parser.py
+++ b/src/prompts_parser.py
@@ -1,0 +1,45 @@
+import logging
+from typing import List
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_prompts_file(file_path: str, delimiter: str = "---") -> List[str]:
+    """Parse prompts split by delimiter lines.
+
+    Delimiter must be alone on a line; multiline prompts are preserved.
+    """
+    if not file_path:
+        logger.error("parse_prompts_file: missing file_path")
+        return []
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("parse_prompts_file: failed to read '%s': %s", file_path, exc)
+        return []
+
+    prompts: List[str] = []
+    current_lines: List[str] = []
+    sep = delimiter.strip()
+
+    def flush_current() -> None:
+        if not current_lines:
+            return
+        text = "".join(current_lines).strip("\n")
+        if text.strip():
+            prompts.append(text)
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if line.strip() == sep:
+            flush_current()
+            current_lines = []
+            continue
+        current_lines.append(raw)
+
+    flush_current()
+    logger.debug("parse_prompts_file: parsed %d prompts from '%s'", len(prompts), file_path)
+    return prompts

--- a/tests/test_prompts_parser.py
+++ b/tests/test_prompts_parser.py
@@ -1,0 +1,42 @@
+import os
+from src.prompts_parser import parse_prompts_file
+
+
+def write_tmp(tmp_path, text: str):
+    p = tmp_path / "prompts.txt"
+    p.write_text(text, encoding="utf-8")
+    return str(p)
+
+
+def test_single_prompt(tmp_path):
+    path = write_tmp(tmp_path, "hello world\n")
+    prompts = parse_prompts_file(path)
+    assert prompts == ["hello world"]
+
+
+def test_multiline_prompt(tmp_path):
+    text = """line1\nline2\n"""
+    path = write_tmp(tmp_path, text)
+    prompts = parse_prompts_file(path)
+    assert prompts == ["line1\nline2"]
+
+
+def test_two_prompts_with_delimiter(tmp_path):
+    text = """first line\n---\nsecond line\n"""
+    path = write_tmp(tmp_path, text)
+    prompts = parse_prompts_file(path)
+    assert prompts == ["first line", "second line"]
+
+
+def test_ignores_empty_chunks(tmp_path):
+    text = """---\n---\nhello\n---\n\n---\n"""
+    path = write_tmp(tmp_path, text)
+    prompts = parse_prompts_file(path)
+    assert prompts == ["hello"]
+
+
+def test_custom_delimiter(tmp_path):
+    text = """a\n***\nb\n"""
+    path = write_tmp(tmp_path, text)
+    prompts = parse_prompts_file(path, delimiter="***")
+    assert prompts == ["a", "b"]


### PR DESCRIPTION
Add batch prompt processing from a file to send multiple prompts sequentially to Fooocus, logging errors and skipping failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a496691-fdb1-43ce-b399-c68d378999f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a496691-fdb1-43ce-b399-c68d378999f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

